### PR TITLE
Make the package MELPA ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # comment-or-uncomment-sexp
-Emacs-lisp command for inteligently commenting and commenting the sexp under point.
 
-This has not been released as a formal (M)Elpa package yet for lack of
-time. Feel free to fork it and release it as a package if you're
-willing to provide maintenance and support for it. If you do, just
-please link to the original blog post where this code was released:
-http://endlessparentheses.com/a-comment-or-uncomment-sexp-command.html
+Emacs-lisp command for inteligently commenting and commenting the sexp
+under point.
+
+For more details and visual demonstration [see my blog post about
+it](http://endlessparentheses.com/a-comment-or-uncomment-sexp-command.html).
+
+To make it easier to use, consider binding it:
+
+```emacs-lisp
+(global-set-key (kbd "C-M-;") #'comment-or-uncomment-sexp)
+```

--- a/comment-or-uncomment-sexp.el
+++ b/comment-or-uncomment-sexp.el
@@ -3,7 +3,10 @@
 ;; Copyright (C) 2019  Artur Malabarba
 
 ;; Author: Artur Malabarba <artur@endlessparentheses.com>
+;; Version: 1.0.0
+;; Homepage: https://github.com/Malabarba/comment-or-uncomment-sexp
 ;; Keywords: convenience
+;; Package-Requires: ((emacs "24"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -19,12 +22,21 @@
 ;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-
-;; 
+;;
+;; Allows for commenting or uncommenting of sexps.
+;;
+;; For visual explanation see:
+;; http://endlessparentheses.com/a-comment-or-uncomment-sexp-command.html
+;;
+;; Usage: M-x comment-or-uncomment-sexp
+;;
+;; Or to make it easier to run, bind it to a key combination:
+;;
+;; (global-set-key (kbd "C-M-;") #'comment-or-uncomment-sexp)
 
 ;;; Code:
 
-(defun uncomment-sexp (&optional n)
+(defun comment-or-uncomment-sexp-uncomment-sexp (&optional n)
   "Uncomment a sexp around point."
   (interactive "P")
   (let* ((initial-point (point-marker))
@@ -81,7 +93,7 @@
     (unless n
       (goto-char initial-point))))
 
-(defun comment-sexp--raw ()
+(defun comment-or-uncomment-sexp-comment-sexp--raw ()
   "Comment the sexp at point or ahead of point."
   (pcase (or (bounds-of-thing-at-point 'sexp)
              (save-excursion
@@ -107,9 +119,9 @@ With a prefix argument N, (un)comment that many sexps."
              (save-excursion
                (comment-forward 1)
                (point))))
-      (uncomment-sexp n)
+      (comment-or-uncomment-sexp-uncomment-sexp n)
     (dotimes (_ (or n 1))
-      (comment-sexp--raw))))
+      (comment-or-uncomment-sexp-comment-sexp--raw))))
 
 (provide 'comment-or-uncomment-sexp)
 ;;; comment-or-uncomment-sexp.el ends here

--- a/comment-or-uncomment-sexp.el
+++ b/comment-or-uncomment-sexp.el
@@ -37,7 +37,8 @@
 ;;; Code:
 
 (defun comment-or-uncomment-sexp-uncomment-sexp (&optional n)
-  "Uncomment a sexp around point."
+  "Uncomment a sexp around point. Or if provided, around the
+point N."
   (interactive "P")
   (let* ((initial-point (point-marker))
          (inhibit-field-text-motion t)


### PR DESCRIPTION
Before submitting the package to MELPA I ran package-lint on the
package and the following issues were highlighted:

```
1:1: warning: "Version:" or "Package-Version:" header is missing. MELPA will handle this, but other archives will not.
1:1: error: Package should have a Homepage or URL header.
1:1: error: package.el cannot parse this buffer: Package lacks a "Version" or "Package-Version" header
1:88: warning: You should depend on (emacs "24") if you need lexical-binding.
21:0: error: Package should have a non-empty ;;; Commentary section.
27:1: error: "uncomment-sexp" doesn't start with package's prefix "comment-or-uncomment-sexp".
84:1: error: "comment-sexp--raw" doesn't start with package's prefix "comment-or-uncomment-sexp".
86:3: error: You should depend on (emacs "24") if you need `pcase'.
```

This PR addresses them all as well as updating the README.